### PR TITLE
Change active selection in switchers to blue

### DIFF
--- a/src/common/sass/widgets/_app-switcher.scss
+++ b/src/common/sass/widgets/_app-switcher.scss
@@ -25,7 +25,7 @@
     
     &:selected {
       color: $inverse_bg_color;
-      background-color: $accent_color;
+      background-color: $primary_color;
     }
   }
   

--- a/src/common/sass/widgets/_workspace-switcher.scss
+++ b/src/common/sass/widgets/_workspace-switcher.scss
@@ -17,7 +17,7 @@
 .ws-switcher-active-up, 
 .ws-switcher-active-down {
   height: 50px;
-  background-color: $accent_color;
+  background-color: $primary_color;
   color: #ffffff;
   border-radius: 2*$pop_radius; 
 }


### PR DESCRIPTION
In the new theme, I thought it would be better to have the selected workspace or app have the accent color instead of the primary color. 

I was wrong.     ._.

Before:
![screenshot from 2018-04-16 16-06-51](https://user-images.githubusercontent.com/5883565/38837722-4a0f4f50-4190-11e8-8f5d-77293b5cc64c.png)


After
![screenshot from 2018-04-16 16-05-14](https://user-images.githubusercontent.com/5883565/38837664-0ae03ee8-4190-11e8-9cd3-023d0bc3d238.png)
