### PR TITLE
Adjust "padding" on switches

### DIFF
--- a/src/common/sass/widgets/_switches.scss
+++ b/src/common/sass/widgets/_switches.scss
@@ -6,7 +6,6 @@
   width: 44px;
   height: 22px;
   background-size: 40px 24px; 
-
 }
 
 .toggle-switch-us,

--- a/src/common/sass/widgets/_switches.scss
+++ b/src/common/sass/widgets/_switches.scss
@@ -4,8 +4,10 @@
  
 .toggle-switch {
   width: 44px;
-  height: 28px;
-  background-size: 40px 24px; }
+  height: 22px;
+  background-size: 40px 24px; 
+
+}
 
 .toggle-switch-us,
 .toggle-switch-intl {


### PR DESCRIPTION
This may cut the top and bottom pixels of the switches off, but they are transparent anyway. This also reduces empty space on the switch, which causes the label next to them to appear closer to centered.