### PR TITLE
Login Screen Tweaks

### DIFF
--- a/src/common/sass/widgets/_auth-dialogs.scss
+++ b/src/common/sass/widgets/_auth-dialogs.scss
@@ -7,7 +7,7 @@
   border: 0 solid rgba($inverse_fg_color, 0.25);
   color: rgba($inverse_fg_color, 0.7);
   border-radius: $circular_radius; 
-  margin-right: $large_padding+$small_padding;
+  margin-right: $large_padding;
   
   &:hover {
     border-color: white;
@@ -29,10 +29,17 @@
     padding: $small_padding $standard_padding;
     selection-background-color: $primary_color;
     selected-color: $inverse_fg_color;
+    min-height: $medium_size;
     
-    &:focus { @include entry(focus, $text_color: $inverse_fg_color); }
-    &:insensitive { @include entry(insensitive, 
-                                   $text_color: $inverse_secondary_fg_color); }
+    &:focus { 
+      @include entry(focus, $text_color: $inverse_fg_color); 
+    }
+    
+    &:insensitive { 
+      @include entry(insensitive, $text_color: $inverse_secondary_fg_color);
+      color: $inverse_fg_color; 
+      padding: $small_padding $standard_padding;
+    }
   }
   
   .modal-dialog-button-box {


### PR DESCRIPTION
* Gets rid of the border around the .framed-user-icon. While pretty, this border doesn't work when you use the default user icon, and thus looks terrible. We'll still crop user icons to a circle.
* Adds a bit of space between the user icon and the User Name. This makes it feel less cramped

Before:
![screenshot from 2018-04-25 10-20-33](https://user-images.githubusercontent.com/5883565/39258956-7e98f6de-4872-11e8-9944-f4684f81a250.png)

After:
![screenshot from 2018-04-25 10-19-27](https://user-images.githubusercontent.com/5883565/39258969-886e0438-4872-11e8-9fbd-c9b8ccf9ce24.png)
