### PR TITLE
Make entries minimally sized

### DIFF
--- a/src/common/sass/widgets/_entries.scss
+++ b/src/common/sass/widgets/_entries.scss
@@ -9,6 +9,7 @@ StEntry {
   selection-background-color: $primary_color;
   selected-color: $white;
   @include entry(normal);
+  min-height: $medium_size;
   
   &:focus { @include entry(focus); }
   &:insensitive { @include entry(insensitive); }


### PR DESCRIPTION
>Should fix shell dialogs moving around by a pixel when typing into entries.
>–@cassidyjames