### PR TITLE
Fixed the button size of the virtual keyboard

### DIFF
--- a/src/common/sass/widgets/_virtual-keyboard.scss
+++ b/src/common/sass/widgets/_virtual-keyboard.scss
@@ -21,7 +21,7 @@
   background-color: $keyboard_key_bg;
   min-height: 2em;
   min-width: 2em;
-  font-size: 32pt;
+  font-size: 16pt;
   border-radius: $pop_radius;
   color: $keyboard_fg_color; 
 }


### PR DESCRIPTION
32pt is too big which results in the keyboard being cut-off and several buttons not to be shown. Changing the value to 16pt (default value of the standard gnome-shell-theme) results in a perfectly usable keyboard tested on 1920x1080@27" and 1920x1080@10.6".