### PR TITLE
Ripple url - Bionic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+pop-gnome-shell-theme (4.0.5) bionic; urgency=medium
+
+  * Fix padding on dash-to-dock item
+  * Fix problem with arrow background colors in non-pop session.
+  * Fix URL of ripple effect image
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 04 Sep 2018 10:33:34 -0600
+
 pop-gnome-shell-theme (4.0.3) bionic; urgency=medium
 
   * Fix for cosmic packaging

--- a/src/common/sass/widgets/_ripple.scss
+++ b/src/common/sass/widgets/_ripple.scss
@@ -3,10 +3,10 @@
 .ripple-box {
   width: 52px;
   height: 52px;
-  background-image: url("assets/corner-ripple-ltr.png");
+  background-image: url("assets/corner-ripple-ltr.svg");
   background-size: contain; 
 
   .ripple-box:rtl {
-    background-image: url("assets/corner-ripple-rtl.png"); 
+    background-image: url("assets/corner-ripple-rtl.svg"); 
   }
 }


### PR DESCRIPTION
* Fix padding on dash-to-dock item
* Fix problem with arrow background colors in non-pop session.
* Fix URL of ripple effect image

Fixes #33 

@brs17 For testing this, please enable the hot corner in tweaks, then trigger the overview using the hot corner several times. Ensure that the ripple is visible in the corner and that there are no error messages about the missing image in `journalctl`