### PR TITLE
Fix System Action Icons

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gnome-shell-theme (4.0.6) bionic; urgency=medium
+
+  * Fix system-action icons (like "Power Off"). See issue #47
+
+ -- Ian Santopietro <ian@system76.com>  Fri, 14 Sep 2018 14:17:44 -0600
+
 pop-gnome-shell-theme (4.0.5) bionic; urgency=medium
 
   * Fix padding on dash-to-dock item

--- a/src/common/sass/widgets/_app-grid.scss
+++ b/src/common/sass/widgets/_app-grid.scss
@@ -11,10 +11,19 @@
 }
 
 .system-action-icon {
-  background-color: black;
-  color: white;
+  margin: 8px 0 $tiny_padding;
+  background-color: $inverse_bg_color;
+  color: $white;
   border-radius: $circular_radius;
   icon-size: $large_icon_size; 
+}
+
+.overview-icon-with-label StLabel {
+  color: $inverse_fg_color;
+}
+
+.overview-icon-with-label {
+  text-align: center;
 }
 
 .app-view-controls {


### PR DESCRIPTION
This .system-action-icon style class and associated labels had inadequate
styling. This corrects this issue.

Fixes #47