### PR TITLE
Icon overlaps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gnome-shell-theme (4.0.6) bionic; urgency=medium
+
+  * Fix icon-overlapping issue (#23)
+
+ -- Ian Santopietro <ian@system76.com>  Mon, 01 Oct 2018 11:39:21 -0600
+
 pop-gnome-shell-theme (4.0.5) bionic; urgency=medium
 
   * Fix padding on dash-to-dock item

--- a/src/common/sass/widgets/_app-grid.scss
+++ b/src/common/sass/widgets/_app-grid.scss
@@ -6,8 +6,6 @@
   spacing: $large_padding*2;
   -shell-grid-horizontal-item-size: 136px;
   -shell-grid-vertical-item-size: 136px; 
-  
-  .overview-icon { icon-size: $large_icon_size*2; }
 }
 
 .system-action-icon {

--- a/src/common/sass/widgets/_app-grid.scss
+++ b/src/common/sass/widgets/_app-grid.scss
@@ -8,6 +8,8 @@
   -shell-grid-vertical-item-size: 136px; 
 }
 
+.overview-icon { icon-size: $large_icon_size*2; }
+
 .system-action-icon {
   margin: 8px 0 $tiny_padding;
   background-color: $inverse_bg_color;

--- a/src/common/sass/widgets/_dashboard.scss
+++ b/src/common/sass/widgets/_dashboard.scss
@@ -24,7 +24,15 @@
   }
 
   .dash-item-container {
-    padding: 4px;
+    padding-top: 1px;
+  }
+  
+  .app-well-app-running-dot {
+    width: $app_running_indicator_size*4;
+    height: $app_running_indicator_size/4;
+    background-color: $accent_color;
+    margin-top: $no_padding; 
+    border-radius: $pop_radius;
   }
 }
 

--- a/src/common/sass/widgets/_dashboard.scss
+++ b/src/common/sass/widgets/_dashboard.scss
@@ -7,24 +7,25 @@
   color: $inverse_fg_color;
   background-color: rgba($inverse_bg_color, 0.85);
   border-radius: 0 $pop_radius $pop_radius 0; 
-}
-  #dash:rtl {
+
+  &:rtl {
     border-radius: $pop_radius 0 0 $pop_radius;
   }
   
-  #dash .placeholder {
+  .placeholder {
     background-image: url("assets/dash-placeholder.svg");
     background-size: .5*$small_icon_size;
     height: .5*$small_icon_size; 
   }
   
-  #dash .empty-dash-drop-target {
+  .empty-dash-drop-target {
     width: 24px;
     height: 24px; 
   }
 
-.dash-item-container {
-  padding: 6px;
+  .dash-item-container {
+    padding: 4px;
+  }
 }
 
 .dash-label {
@@ -37,5 +38,5 @@
 }
 
 .show-apps {
-  padding-right: 8px;
+  padding: 8px;
 }


### PR DESCRIPTION
This makes it harder to tell which running dot (line) coresponds with which
app, but it prevents the icons from overlapping the Show Apps button.

Fixes #23