### PR TITLE
Support for GNOME Shell 3.30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 SHELL = /bin/bash
 COLOR_VARIANTS = '' '-dark' '-light'
 SIZE_VARIANTS = '' '-slim'
-VERSIONS = '3.18' '3.26' '3.28'
+VERSIONS = '3.18' '3.26' '3.28' '3.30'
 SASSC_OPT=-M -t expanded
 BASE_DIR=/usr/share/themes
 REPODIR=$(CURDIR)
 SRCDIR=$(REPODIR)/build
-GNOMEVER=3.26
+GNOMEVER=3.28
 DEBIAN=0
 
 all: gnome-shell

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pop-gnome-shell-theme (4.0.8) bionic; urgency=medium
+
+  * Adds support for GNOME Shell 3.30
+  * Fixes sliders in 3.30
+
+ -- Ian Santopietro <ian@system76.com>  Thu, 11 Oct 2018 11:51:24 -0600
+
 pop-gnome-shell-theme (4.0.7) bionic; urgency=medium
 
   * Fix icon-overlapping issue (#23)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gnome-shell-theme (4.0.6) bionic; urgency=medium
+
+  * Fix icon-overlapping issue (#23)
+
+ -- Ian Santopietro <ian@system76.com>  Mon, 01 Oct 2018 11:39:21 -0600
+
 pop-gnome-shell-theme (4.0.5) bionic; urgency=medium
 
   * Fix padding on dash-to-dock item

--- a/src/3.28/sass/widgets/_sliders.scss
+++ b/src/3.28/sass/widgets/_sliders.scss
@@ -1,0 +1,15 @@
+/* 
+ * Slider *
+ */
+
+.slider {
+  height: 1em;
+  color: $primary_color;
+  -slider-height: 0.3em;
+  -slider-background-color: $track_color;
+  -slider-border-color: transparent;
+  -slider-active-background-color: $primary_color;
+  -slider-active-border-color: transparent;
+  -slider-border-width: 1px;
+  -slider-handle-radius: 6px; 
+}

--- a/src/common/sass/widgets/_app-grid.scss
+++ b/src/common/sass/widgets/_app-grid.scss
@@ -6,8 +6,6 @@
   spacing: $large_padding*2;
   -shell-grid-horizontal-item-size: 136px;
   -shell-grid-vertical-item-size: 136px; 
-  
-  .overview-icon { icon-size: $large_icon_size*2; }
 }
 
 .system-action-icon {

--- a/src/common/sass/widgets/_app-grid.scss
+++ b/src/common/sass/widgets/_app-grid.scss
@@ -8,6 +8,8 @@
   -shell-grid-vertical-item-size: 136px; 
 }
 
+.overview-icon { icon-size: $large_icon_size*2; }
+
 .system-action-icon {
   margin: 8px 0 $tiny_padding;
   background-color: $inverse_bg_color;

--- a/src/common/sass/widgets/_dashboard.scss
+++ b/src/common/sass/widgets/_dashboard.scss
@@ -24,7 +24,15 @@
   }
 
   .dash-item-container {
-    padding: 4px;
+    padding-top: 1px;
+  }
+  
+  .app-well-app-running-dot {
+    width: $app_running_indicator_size*4;
+    height: $app_running_indicator_size/4;
+    background-color: $accent_color;
+    margin-top: $no_padding; 
+    border-radius: $pop_radius;
   }
 }
 

--- a/src/common/sass/widgets/_dashboard.scss
+++ b/src/common/sass/widgets/_dashboard.scss
@@ -7,24 +7,25 @@
   color: $inverse_fg_color;
   background-color: rgba($inverse_bg_color, 0.85);
   border-radius: 0 $pop_radius $pop_radius 0; 
-}
-  #dash:rtl {
+
+  &:rtl {
     border-radius: $pop_radius 0 0 $pop_radius;
   }
   
-  #dash .placeholder {
+  .placeholder {
     background-image: url("assets/dash-placeholder.svg");
     background-size: .5*$small_icon_size;
     height: .5*$small_icon_size; 
   }
   
-  #dash .empty-dash-drop-target {
+  .empty-dash-drop-target {
     width: 24px;
     height: 24px; 
   }
 
-.dash-item-container {
-  padding: 6px;
+  .dash-item-container {
+    padding: 4px;
+  }
 }
 
 .dash-label {
@@ -37,5 +38,5 @@
 }
 
 .show-apps {
-  padding-right: 8px;
+  padding: 8px;
 }

--- a/src/common/sass/widgets/_sliders.scss
+++ b/src/common/sass/widgets/_sliders.scss
@@ -5,11 +5,11 @@
 .slider {
   height: 1em;
   color: $primary_color;
-  -slider-height: 0.3em;
-  -slider-background-color: $track_color;
-  -slider-border-color: transparent;
-  -slider-active-background-color: $primary_color;
-  -slider-active-border-color: transparent;
-  -slider-border-width: 1px;
+  -barlevel-height: 0.3em;
+  -barlevel-background-color: $track_color;
+  -barlevel-border-color: transparent;
+  -barlevel-active-background-color: $primary_color;
+  -barlevel-active-border-color: transparent;
+  -barlevel-border-width: 1px;
   -slider-handle-radius: 6px; 
 }


### PR DESCRIPTION
This PR adds support for GNOME Shell 3.30 to the Pop GNOME Shell theme. We do this by backing up old 3.28-specific changes into the 3.28 folder, and creating a new folder for 3.30, which will be the default going forward. 

This version currently keeps 3.28 as the default to install, for merging into master_bionic. A separate PR will be used for inclusion into cosmic.

This PR also incorporates Icon overlap fixes for #23 