### PR TITLE
Modal buttons Styling

### DIFF
--- a/src/common/sass/_colors.scss
+++ b/src/common/sass/_colors.scss
@@ -11,6 +11,34 @@
   @return mix($c, $grey_800, 75%);
 }
 
+// Some color functions to opacitize colors for certain functions
+@function to800($color) {
+  @return rgba($color, 0.8);
+}
+@function to600($color) {
+  @return rgba($color, 0.6);
+}
+@function to400($color) {
+  @return rgba($color, 0.4);
+}
+@function to200($color) {
+  @return rgba($color, 0.2);
+}
+@function to100($color) {
+  @return rgba($color, 0.1);
+}
+@function to50($color) {
+  @return rgba($color, 0.05);
+}
+
+// Main Accent Colors
+$color_theme_1: if($variant=='dark', $blue_700, $blue_500);
+$light_color_1: $blue_300;
+$dark_color_1: $blue_700;
+$color_theme_2: if($variant=='dark', $orange_700, $orange_500);
+$light_color_2: $orange_300;
+$dark_color_2: $orange_900;
+
 // Foreground colors
 $dark_fg_color:   rgba($brown_700, 0.87);
 $light_fg_color:  $white;

--- a/src/common/sass/widgets/_buttons.scss
+++ b/src/common/sass/widgets/_buttons.scss
@@ -17,26 +17,54 @@
 }
 
 .modal-dialog-linked-button {
-  min-height: $button_size * 2;
-  padding: 0 $large_padding;
-  border-top: $border_size solid $border_color !important;
-  border-right-width: 0;
+  min-height: $button_size;
+  margin: 6px 0;
+  padding: $tiny_padding - 2px $large_padding;
   @include font(button);
   @include button(flat-normal);
-  &:hover { @include button(flat-hover); }
-  &:active { @include button(flat-active); }
-  &:insensitive { @include button(flat-insensitive); }
-  &:focus { @include button(flat-focus); }
+  background-color: $base_color;
+  color: $fg_color;
+  
+  &:focus { 
+    @include button(flat-focus);
+    background-color: $base_color;
+    color: $color_theme_2;
+  }
+  
+  &:hover { 
+    @include button(flat-hover);
+    background-color: to100($color_theme_2);
+    
+    &:focus {
+      color: $color_theme_2;
+    }
+  }
+  
+  &:active { 
+    @include button(flat-active);
+    background-color: to200($color_theme_2);
+    
+    &:focus {
+      color: $color_theme_2;
+    }
+  }
+  
+  &:insensitive { 
+    @include button(flat-insensitive);
+  }
 
   &:first-child {
-    border-radius: 0 0 0 $pop_radius;
+    margin-left: 6px;
+    border-radius: $pop_radius 0 0 $pop_radius;
   }
   &:last-child {
+    margin-right: 6px;
     border-right-width: 0;
-    border-radius: 0 0 $pop_radius 0;
+    border-radius: 0 $pop_radius $pop_radius 0;
   }
   &:first-child:last-child {
+    margin: 6px;
     border-right-width: 0;
-    border-radius: 0 0 $pop_radius $pop_radius;
+    border-radius: $pop_radius;
   }
 }

--- a/src/common/sass/widgets/_popovers-menus.scss
+++ b/src/common/sass/widgets/_popovers-menus.scss
@@ -98,6 +98,7 @@
   border: none;
   /* wish we could do 50% */
   padding: $standard_padding; 
+  -st-icon-style: symbolic;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
The new V4 GTK theme includes a new style for buttons in a modal dialog. This PR updates the styling in the GNOME Shell theme to closely match that present there.

It also tells the system menu to use symbolic icons for the Power, Suspend, Lock, and Settings icons.

Depended on #53 