### PR TITLE
Version 4.0.9 - Fix Spamming the syslog with Error messages.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gnome-shell-theme (4.0.9) cosmic; urgency=medium
+
+  * Bugfix: Update styling to reduce the indcidence of log spam. (#68)
+
+ -- Ian Santopietro <isantop@gmail.com>  Wed, 09 Jan 2019 10:34:58 -0700
+
 pop-gnome-shell-theme (4.0.8) bionic; urgency=medium
 
   * Adds support for GNOME Shell 3.30

--- a/src/common/sass/_variables.scss
+++ b/src/common/sass/_variables.scss
@@ -128,11 +128,11 @@ $menu_transition: all 0.1s $sharp_curve;
 // box-shadow 1px blur doesn't draw correctly, see
 // https://bugzilla.gnome.org/show_bug.cgi?id=738484
 // $shadow_1: 0 1px 1.5px rgba(0, 0, 0, 0.12), 0 1px 1px rgba(0, 0, 0, 0.24);
-$shadow_0: 0 1px 1px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.08);
-$shadow_1: 0 1px 1px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-$shadow_2: 0 3px 3px rgba(0, 0, 0, 0.16), 0 3px 3px rgba(0, 0, 0, 0.23);
-$shadow_3: 0 10px 10px rgba(0, 0, 0, 0.19), 0 6px 3px rgba(0, 0, 0, 0.23);
-$shadow_4: 0 14px 14px rgba(0, 0, 0, 0.25), 0 10px 5px rgba(0, 0, 0, 0.22);
-$shadow_5: 0 19px 19px rgba(0, 0, 0, 0.30), 0 15px 6px rgba(0, 0, 0, 0.22);
+$shadow_0: 0 1px 2px rgba(0, 0, 0, 0.08);
+$shadow_1: 0 1px 2px rgba(0, 0, 0, 0.24);
+$shadow_2: 0 3px 3px rgba(0, 0, 0, 0.23);
+$shadow_3: 0 6px 3px rgba(0, 0, 0, 0.23);
+$shadow_4: 0 10px 5px rgba(0, 0, 0, 0.22);
+$shadow_5: 0 15px 6px rgba(0, 0, 0, 0.22);
 
 $text_shadow: 0 1px 5px rgba(0, 0, 0, 0.6);

--- a/src/common/sass/widgets/_osd.scss
+++ b/src/common/sass/widgets/_osd.scss
@@ -31,7 +31,7 @@
     -barlevel-background-color: $track_color;
     -barlevel-active-background-color: $color_theme_1;
     -barlevel-overdrive-color: $destructive_color;
-    -barlevel-overdrive-separator-width: 0.2em;
+    -barlevel-overdrive-separator-width: 2px;
   }
   
   .level-bar {

--- a/src/common/sass/widgets/_sliders.scss
+++ b/src/common/sass/widgets/_sliders.scss
@@ -10,6 +10,7 @@
   -barlevel-border-color: transparent;
   -barlevel-active-background-color: $primary_color;
   -barlevel-active-border-color: transparent;
+  -barlevel-overdrive-color: $destructive_color;
   -barlevel-border-width: 1px;
   -slider-handle-radius: 6px; 
 }

--- a/src/common/sass/widgets/_switches.scss
+++ b/src/common/sass/widgets/_switches.scss
@@ -9,10 +9,6 @@
   background-clip: content-box;
 }
 
-.toggle-switch + StLabel {
-  margin-top: 150px;
-}
-
 .toggle-switch-us,
 .toggle-switch-intl {
   background-image: url("assets/switch-off.svg");


### PR DESCRIPTION
Fixes #68 
Squashed commit of the following:
commit e65a7829f8bdaf04672c14f939cea7def619ec7f
Author: Ian Santopietro <isantop@system76.com>
Date:   Wed Jan 9 10:29:28 2019 -0700

    Remove double-defined shadows

    GNOME Shell apparently doesn't support more than a single
    shadow definition per box-shadow. Not that CSS or GTK-CSS
    have any such problems, but....

commit b329ce239651d8e76c9b51cf091024bdb1d42ae3
Author: Ian Santopietro <isantop@system76.com>
Date:   Wed Jan 9 10:25:54 2019 -0700

    Add overdrive styling to remove error messages

commit a699a1ff1a4be08b6df0e91e91b5248ca86443ef
Author: Ian Santopietro <isantop@system76.com>
Date:   Wed Jan 9 10:17:30 2019 -0700

    Remove the theme's + combinator