### PR TITLE
Bugfix 74 dialog width

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pop-gnome-shell-theme (4.0.12) cosmic; urgency=medium
+
+  * Allow dialogs to use variable width. (#73 and #74)
+
+ -- Ian Santopietro <isantop@gmail.com>  Thu, 31 Jan 2019 15:55:32 -0700
+
 pop-gnome-shell-theme (4.0.10) cosmic; urgency=medium
 
   * Fix invisible switches in dark variant (#66)

--- a/src/common/sass/widgets/_modal-dialogs.scss
+++ b/src/common/sass/widgets/_modal-dialogs.scss
@@ -20,7 +20,7 @@
   background-color: $bg_color;
   box-shadow: $shadow_4;
   border: none;
-  width: $modal_size;
+  //width: $modal_size;
   
   .modal-dialog-content-box {
     padding: $huge_padding; 
@@ -98,7 +98,6 @@
 }
 
 .end-session-dialog-description {
-  width: $modal_size;
   padding-bottom: $standard_padding; 
   color: $secondary_fg_color;
   &:rtl {
@@ -107,7 +106,6 @@
 }
 
 .end-session-dialog-warning {
-  width: $modal_size;
   color: $error_color;
   padding-top: $tiny_padding; 
   &:rtl {
@@ -174,7 +172,6 @@
     padding-top: $standard_padding;
     padding-left: $large_padding;
     padding-bottom: $tiny_padding;
-    max-width: $modal_size; 
     &:rtl {
       padding-left: 0;
       padding-right: $large_padding; 
@@ -183,7 +180,6 @@
   
   .message-dialog-body {
     padding-left: $large_padding;
-    width: $modal_size - 2em; 
     &:rtl {
       padding-left: 0;
       padding-right: $large_padding;  
@@ -227,7 +223,6 @@
 
 /* Password or Authentication Dialog */
 .prompt-dialog {
-  width: $modal_size+5em;
   
   .message-dialog-main-layout {
     spacing: $huge_padding;


### PR DESCRIPTION
Removes setting a width on Dialogs. Allows dialog width to be sized based on content. 

Fixes #74 
Fixes #73 